### PR TITLE
Cyrus::MailboxVersion: Test sentdate properly with different TZs

### DIFF
--- a/cassandane/Cassandane/Cyrus/MailboxVersion.pm
+++ b/cassandane/Cassandane/Cyrus/MailboxVersion.pm
@@ -50,6 +50,7 @@ use Storable 'dclone';
 use MIME::Base64 qw(encode_base64 encode_base64url decode_base64url);
 use Encode qw(decode_utf8);
 use Cwd qw(abs_path getcwd);
+use POSIX qw(mktime);
 
 use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
@@ -249,6 +250,19 @@ sub index_file_records {
     }
 
     return @recs;
+}
+
+sub sentdate_ts {
+    my ($self, $seconds) = @_;
+
+    my @lt = localtime($seconds);
+
+    # zero out sec/min/hour to truncate to day
+    $lt[0] = $lt[1] = $lt[2] = 0;
+
+    # Cyrus stores sentdate offset by local timezone, not UTC, so we need
+    # mktime to calculate that for us like cyrus does
+    return mktime(@lt);
 }
 
 use Cassandane::Tiny::Loader 'tiny-tests/MailboxVersion';

--- a/cassandane/tiny-tests/MailboxVersion/cyrus_indexfile_19
+++ b/cassandane/tiny-tests/MailboxVersion/cyrus_indexfile_19
@@ -129,7 +129,10 @@ sub test_cyrus_indexfile_19
         InternalDate  => num(time, 60),
         LastUpdated   => num(time, 60),
         SaveDate      => num(time, 60),
-        SentDate      => num(time - (time % 86400), 60), # cyrus clamps to day
+        SentDate      => any(
+            $self->sentdate_ts(time), # Start of today
+            $self->sentdate_ts(time) - 86400, # Start of yesterday
+        ),
 
         CacheCrc      => ignore(),
         RecordCrc     => ignore(),
@@ -267,8 +270,10 @@ sub test_cyrus_indexfile_19
         )
     } qw(RecentTime InternalDate SaveDate);
 
-    # cyrus clamps to day
-    $expect{SentDate} = num(time - (time % 86400), 60);
+    $expect{SentDate} = any(
+        $self->sentdate_ts(time), # Start of today
+        $self->sentdate_ts(time) - 86400, # Start of yesterday
+    );
     $expect{SentDate_ns} = 0;
 
     my @recs = $self->index_file_records($index);

--- a/cassandane/tiny-tests/MailboxVersion/cyrus_indexfile_20
+++ b/cassandane/tiny-tests/MailboxVersion/cyrus_indexfile_20
@@ -144,8 +144,8 @@ sub test_cyrus_indexfile_20
         #   - account for day wrapping to next by the time we get here by
         #   - allowing SentDate to be start of *yesterday*
         SentDate      => any(
-            num((time - (time % 86400)) * $ns_in_a_sec, $sixty_sec_ns),
-            num((time - (time % 86400) - 86400) * $ns_in_a_sec, $sixty_sec_ns),
+            $self->sentdate_ts(time) * $ns_in_a_sec, # Start of today
+            ($self->sentdate_ts(time) - 86400) * $ns_in_a_sec, # Start of yesterday
         ),
 
         CacheCrc      => ignore(),
@@ -289,7 +289,10 @@ sub test_cyrus_indexfile_20
     $expect{InternalDate_ns} = num(0, 1000000000);
 
     # cyrus clamps to day
-    $expect{SentDate} = num(time - (time % 86400), 60);
+    $expect{SentDate} = any(
+        $self->sentdate_ts(time), # Start of today
+        $self->sentdate_ts(time) - 86400, # Start of yesterday
+    ),
     $expect{SentDate_ns} = 0;
 
     my @recs = $self->index_file_records($index);


### PR DESCRIPTION
It turns out sentdate isn't stored as start of a particular day from the Epoch, but from the start of the day +/- the offset from the local timezone.

Adjust the tests to account for that so it works whether a machine is UTC or EDT or what have you.